### PR TITLE
Pass in needed interpolation data

### DIFF
--- a/app/controllers/arturo/features_controller.rb
+++ b/app/controllers/arturo/features_controller.rb
@@ -80,7 +80,7 @@ module Arturo
         flash[:notice] = t('arturo.features.flash.updated', :name => @feature.to_s)
         redirect_to arturo_engine.feature_path(@feature)
       else
-        flash[:alert] = t('arturo.features.flash.error_updating', :name => @feature.to_s)
+        flash[:alert] = t('arturo.features.flash.error_updating', :name => @feature.name, :errors => @feature.errors.full_messages.join("\n"))
         render :action => 'edit'
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
         created: "Created %{name}"
         error_creating: "Sorry, there was an error creating the feature."
         updated: "Updated %{name}"
-        error_updating: "Could not update feature #%{id}: %{errors}."
+        error_updating: "Could not update %{name}: %{errors}."
         removed: "Removed %{name}"
         error_removing: "Sorry, there was an error removing %{name}"
     no_such_feature:

--- a/test/dummy_app/test/functional/features_controller_admin_test.rb
+++ b/test/dummy_app/test/functional/features_controller_admin_test.rb
@@ -58,6 +58,12 @@ class ArturoFeaturesControllerAdminTest < Arturo::IntegrationTest
     assert_redirected_to "/arturo/features/#{@features.first.to_param}"
   end
 
+  def test_put_invalid_update
+    put "/arturo/features/#{@features.first.id}", :feature => { :deployment_percentage => '-10' }
+    assert_response :success
+    assert_equal "Could not update #{@features.first.name}: Deployment Percentage must be greater than or equal to 0.", @controller.flash[:alert]
+  end
+
   def test_delete_destroy
     delete "/arturo/features/#{@features.first.id}"
     assert_redirected_to '/arturo/features'


### PR DESCRIPTION
We added a validation and it caused the updating to error out but this exposed the fact that there was missing data in the interpolated error message.

@jamesarosen 

Without fix (failing test):

````
ArturoFeaturesControllerAdminTest#test_put_invalid_update:
I18n::MissingInterpolationArgument: missing interpolation argument :id in "Could not update feature #%{id}: %{errors}." ({:name=>"Feature Feature 41", :errors=>#<ActiveModel::Errors:0x007feb598fb780 @base=<Arturo::Feature Feature 41, deployed to -10%>, @messages={:deployment_percentage=>["must be greater than or equal to 0"]}>} given)
````