### PR TITLE
check for definition of Rails::VERSION::MAJOR

### DIFF
--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -4,7 +4,7 @@ module Arturo
   require 'arturo/feature_availability'
   require 'arturo/feature_management'
   require 'arturo/feature_caching'
-  require 'arturo/engine' if defined?(Rails) && Rails::VERSION::MAJOR >= 3
+  require 'arturo/engine' if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR >= 3
 
   class << self
     # Quick check for whether a feature is enabled for a recipient.


### PR DESCRIPTION
Some gems will declare the `Rails` module even without having a dependency on the rails gem.

I'm looking at you `rails-dom-testing`.
https://github.com/rails/rails-dom-testing/blob/master/lib/rails/dom/testing/version.rb

So you can end up with a `Rails` module without a `VERSION` constant.

Hi James!